### PR TITLE
adds support for legacy tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # rooibos-preprocessor CHANGELOG
 
+## 3.0.9 - reintroduces legacy support
+
+### Added
+
+  - legacy unit testing support is reintroduced. Any projects that adhere to the roku unit testing library pre-annotation syntax, will automatically run.
+    @only and @ignore is supported for test suites, and test cases.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+  - crash when any function calls asString on an aa that has mocked functions
+  - race crash as reported here https://github.com/georgejecook/rooibos/issues/53
+
+
 ## 3.0.8 - out of beta - yay!
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rooibos-preprocessor",
-  "version": "3.0.4-beta",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1119,17 +1119,16 @@
       }
     },
     "brs": {
-      "version": "0.13.0-rc.3",
-      "resolved": "https://registry.npmjs.org/brs/-/brs-0.13.0-rc.3.tgz",
-      "integrity": "sha512-iMYCOCd1emoOiahdFdn41VWXchdQ2gd7Gd2SLOJUcWWYhK7HTgVCAtBmpQInFaq57tWSZ2v1QNVY5QQOzYJR5g==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/brs/-/brs-0.13.0.tgz",
+      "integrity": "sha512-v5LaVNEltZpO12Guw+TWicTwWF8oosioQv6Ln4u3eyBJI1WQe496QORBf1toMz1hiqmeFIGGZd+wT/T9Sepu4A==",
       "requires": {
         "commander": "^2.12.2",
         "lolex": "^3.0.0",
         "long": "^3.2.0",
         "luxon": "^1.8.3",
         "memory-fs": "^0.4.1",
-        "p-settle": "^2.1.0",
-        "pify": "^4.0.1"
+        "p-settle": "^2.1.0"
       }
     },
     "buffer-equal": {
@@ -1320,9 +1319,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2125,7 +2124,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
       "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5",
         "yargs": "~1.2.6"
@@ -2493,9 +2491,9 @@
       }
     },
     "luxon": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.15.0.tgz",
-      "integrity": "sha512-HIpK4zIonObWHj9UC80ElykmM/0jTuuXcbPYBYbDGZ3Cq2bL9rACcmppoc6zm5JnmHpnK5bRMIp8/+ei4O0y2Q=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.16.0.tgz",
+      "integrity": "sha512-qaqB+JwpGwtl7UbIXng3A/l4W/ySBr8drQvwtMLZBMiLD2V+0fEnPWMrs+UjnIy9PsktazQaKvwDUCLzoWz0Hw=="
     },
     "make-error": {
       "version": "1.3.5",
@@ -3910,11 +3908,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -4545,7 +4538,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
       "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-      "dev": true,
       "requires": {
         "minimist": "^0.1.0"
       },
@@ -4553,8 +4545,7 @@
         "minimist": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-          "dev": true
+          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rooibos-preprocessor",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "preprocessor for roku brightscript and scenegraph projects, using rooibos",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ program
 .option('-o, --outputPath [path]', 'Path to package output directory. This is where generated files, required for execution will be copied to. Relative to projectPath, defaults to source')
 .option('-f, --showFailuresOnly', 'Show results for failed tests, if any. If none fail, then all results are shown')
 .option('-F, --failFast', 'Test execution will stop at the first failure')
+.option('-l, --legacySupport', 'legacy tests are included in the rooibos run, when this flag is set - see the rooibos docs for more info')
 .description(`
   processes a brightscript SceneGraph project and creates json data structures
   which can be used by the rooibos unit testing framework, or vsCode IDE
@@ -45,7 +46,8 @@ program
       sourceFilePattern: options.sourceFilePattern,
       outputPath: options.outputPath,
       showFailuresOnly: options.showFailuresOnly,
-      failFast: options.failFast
+      failFast: options.failFast,
+      legacySupport: options.legacySupport
     };
   }
 

--- a/src/lib/ItGroup.ts
+++ b/src/lib/ItGroup.ts
@@ -1,7 +1,7 @@
 import { TestCase } from './TestCase';
 
 export class ItGroup {
-  constructor(name: string, isSolo: boolean, isIgnore: boolean, filename: string) {
+  constructor(name: string, isSolo: boolean, isIgnore: boolean, filename: string, isLegacy: boolean = false) {
     this.name = name;
     this.isSolo = isSolo;
     this.hasSoloTests = false;
@@ -11,6 +11,7 @@ export class ItGroup {
     this.testCases = [];
     this.ignoredTestCases = [];
     this.soloTestCases = [];
+    this.isLegacy = isLegacy;
   }
 
   public isIncluded: boolean;
@@ -27,6 +28,7 @@ export class ItGroup {
   public beforeEachFunctionName: string;
   public afterEachFunctionName: string;
   public hasSoloTests: boolean;
+  public isLegacy: boolean;
 
   public asJson(): object {
     return {
@@ -66,6 +68,7 @@ export class ItGroup {
         beforeEachFunctionName: "${this.beforeEachFunctionName || ''}"
         afterEachFunctionName: "${this.afterEachFunctionName || ''}"
         isSolo: ${this.isSolo}
+        isLegacy: ${this.isLegacy}
         isIgnored: ${this.isIgnored}
         hasSoloTests: ${this.hasSoloTests}
         name: "${this.name || ''}"

--- a/src/lib/ProcessorConfig.ts
+++ b/src/lib/ProcessorConfig.ts
@@ -18,6 +18,7 @@ export interface ProcessorConfig {
   logLevel: ProcessorLogLevel;
   showFailuresOnly: boolean;
   failFast: boolean;
+  legacySupport: boolean;
 }
 
 export function createProcessorConfig(config: any): ProcessorConfig {
@@ -29,6 +30,7 @@ export function createProcessorConfig(config: any): ProcessorConfig {
   config.isRecordingCodeCoverage = config.isRecordingCodeCoverage === true;
   config.showFailuresOnly = config.showFailuresOnly === true;
   config.failFast = config.failFast === true;
+  config.legacySupport = config.legacySupport === true;
   config.outputPath = config.outputPath || 'source';
 
   if (!config.projectPath) {

--- a/src/lib/RooibosProcessor.ts
+++ b/src/lib/RooibosProcessor.ts
@@ -53,6 +53,7 @@ export class RooibosProcessor {
 
     outputText += '\n' + this.createTestsHeaderText();
     outputText += '\n' + this.runtimeConfig.createTestSuiteLookupFunction();
+    outputText += '\n' + this.runtimeConfig.createIgnoredTestsInfoFunction();
     outputText += '\n' + this.createFileFooterText();
     let mapFileName = path.join(this.config.projectPath, this.config.outputPath, 'rooibosFunctionMap.brs');
     const file = new File(path.resolve(path.dirname(mapFileName)), path.dirname(mapFileName), path.basename(mapFileName), '.brs');

--- a/src/lib/RuntimeConfig.ts
+++ b/src/lib/RuntimeConfig.ts
@@ -39,7 +39,7 @@ export class RuntimeConfig {
   public process() {
     //TODO - make async.
     //TODO - cachetimestamps for files - for performance
-    let testSuiteBuilder = new TestSuiteBuilder(50);
+    let testSuiteBuilder = new TestSuiteBuilder(50, this._config.legacySupport);
     const glob = require('glob-all');
     let targetPath = path.resolve(this._config.projectPath);
     debug(`processing files at path ${targetPath} with pattern ${this._config.testsFilePattern}`);
@@ -73,6 +73,22 @@ export class RuntimeConfig {
     }
 
     this.updateIncludedFlags();
+  }
+
+  public createIgnoredTestsInfoFunction(): string {
+    let text = `
+    function RBSFM_getIgnoredTestInfo()
+        return {
+          "count": ${this.ignoredCount}
+          "items":[
+        `;
+    this.ignoredTestNames.forEach((ignoredText) => {
+      text += `"${ignoredText}",\n`;
+    });
+    text += `
+      ]}
+    end function\n`;
+    return text;
   }
 
   public createTestSuiteLookupFunction(): string {

--- a/src/lib/TestSuite.spec.ts
+++ b/src/lib/TestSuite.spec.ts
@@ -27,7 +27,7 @@ function copyFiles() {
 
 describe('TestSuite tests ', function() {
   beforeEach(() => {
-    builder = new TestSuiteBuilder(50);
+    builder = new TestSuiteBuilder(50, false);
   });
 
   describe('asJson', function() {

--- a/src/lib/TestSuite.ts
+++ b/src/lib/TestSuite.ts
@@ -17,6 +17,7 @@ export class TestSuite {
     this.tearDownFunctionName = '';
     this.isNodeTest = false;
     this.nodeTestFileName = '';
+    this.isLegacy = false;
   }
 
   public filePath: string;
@@ -38,6 +39,7 @@ export class TestSuite {
   public nodeTestFileName: string;
   public afterEachFunctionName: string;
   public rawParams: string;
+  public isLegacy: boolean;
 
   public asJson(): object {
     return {
@@ -78,6 +80,7 @@ export class TestSuite {
       setupFunctionName: "${this.setupFunctionName || ''}"
       tearDownFunctionName: "${this.tearDownFunctionName || ''}"
       isNodeTest: ${this.isNodeTest}
+      isLegacy: ${this.isLegacy}
       nodeTestFileName: "${this.nodeTestFileName || ''}"
       beforeEachFunctionName: "${this.beforeEachFunctionName || ''}"
       afterEachFunctionName: "${this.afterEachFunctionName || ''}"

--- a/src/lib/TestSuiteBuilder.spec.ts
+++ b/src/lib/TestSuiteBuilder.spec.ts
@@ -29,7 +29,7 @@ function copyFiles() {
 
 describe('TestSuiteBuilder tests ', function() {
   beforeEach(() => {
-    builder = new TestSuiteBuilder(50);
+    builder = new TestSuiteBuilder(50, false);
   });
 
   describe('Initialization', function() {
@@ -129,6 +129,7 @@ describe('TestSuiteBuilder tests ', function() {
       expect(testSuite.itGroups[0].testCases[0].expectedNumberOfParams).to.equal(2);
       expect(testSuite.itGroups[0].testCases[0].rawParams.length).to.equal(2);
 
+      expect(testSuite.itGroups[0].filename).to.equal('paramsTest');
       expect(testSuite.itGroups[0].testCases[1].expectedNumberOfParams).to.equal(2);
       expect(testSuite.itGroups[0].testCases[1].rawParams.length).to.equal(2);
     });
@@ -153,6 +154,112 @@ describe('TestSuiteBuilder tests ', function() {
       expect(testSuite.itGroups[0].testCases[0].expectedNumberOfParams).to.equal(3);
       expect(testSuite.itGroups[0].testCases[0].rawParams.length).to.equal(3);
       expect(testSuite.itGroups[0].testCases[0].rawParams[1].type).to.equal('http://101.rooibos.com');
+    });
+
+    describe('legacy support', function() {
+      beforeEach(() => {
+        builder = new TestSuiteBuilder(50, true);
+      });
+
+      it('parsing of tests and asserts', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.hasSoloTests).to.be.false;
+        expect(testSuite.isSolo).to.be.false;
+        expect(testSuite.hasIgnoredTests).to.be.false;
+        expect(testSuite.isIgnored).to.be.false;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.itGroups[0].filename).to.equal('legacyFrameworkTests');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(7);
+        expect(testSuite.itGroups[0].testCases[2].funcName).to.equal('testcase__main_checkstreamformattype');
+        expect(testSuite.itGroups[0].testCases[2].name).to.equal('CheckStreamFormatType');
+        expect(testSuite.itGroups[0].testCases[2].lineNumber).to.equal(79);
+        expect(testSuite.itGroups[0].testCases[2].assertLineNumberMap['0']).to.equal(81);
+        expect(testSuite.itGroups[0].testCases[2].assertLineNumberMap['1']).to.equal(82);
+        expect(testSuite.itGroups[0].testCases[2].assertLineNumberMap['2']).to.equal(83);
+      });
+
+      it('parsing of ignored test', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests_isIgnored.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.hasSoloTests).to.be.false;
+        expect(testSuite.isSolo).to.be.false;
+        expect(testSuite.hasIgnoredTests).to.be.false;
+        expect(testSuite.isIgnored).to.be.true;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(7);
+      });
+
+      it('parsing of solo', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests_isSolo.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.hasSoloTests).to.be.false;
+        expect(testSuite.isSolo).to.be.true;
+        expect(testSuite.hasIgnoredTests).to.be.false;
+        expect(testSuite.isIgnored).to.be.false;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(7);
+      });
+
+      it('parsing of solo tests', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests_solos.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.hasSoloTests).to.be.true;
+        expect(testSuite.isSolo).to.be.true;
+        expect(testSuite.hasIgnoredTests).to.be.false;
+        expect(testSuite.isIgnored).to.be.false;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(5);
+        expect(testSuite.itGroups[0].soloTestCases.length).to.equal(2);
+        expect(testSuite.itGroups[0].soloTestCases[1].funcName).to.equal('testcase__main_checkstreamformattype');
+        expect(testSuite.itGroups[0].soloTestCases[1].name).to.equal('CheckStreamFormatType');
+        expect(testSuite.itGroups[0].soloTestCases[1].lineNumber).to.equal(103);
+      });
+
+      it('parsing of ignored tests', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests_ignoredTests.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.hasSoloTests).to.be.false;
+        expect(testSuite.isSolo).to.be.false;
+        expect(testSuite.hasIgnoredTests).to.be.true;
+        expect(testSuite.isIgnored).to.be.false;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(5);
+        expect(testSuite.itGroups[0].soloTestCases.length).to.equal(0);
+        expect(testSuite.itGroups[0].ignoredTestCases.length).to.equal(2);
+        expect(testSuite.itGroups[0].ignoredTestCases[0].funcName).to.equal('testcase__main_checkdatacount');
+        expect(testSuite.itGroups[0].ignoredTestCases[0].name).to.equal('CheckDataCount');
+        expect(testSuite.itGroups[0].ignoredTestCases[1].funcName).to.equal('testcase__main_checkstreamformattype');
+        expect(testSuite.itGroups[0].ignoredTestCases[1].name).to.equal('CheckStreamFormatType');
+      });
+
+      it('parsing of setup and teardown', () => {
+        let file = makeFile(specDir, `legacyFrameworkTests_setupAndTearDown.brs`);
+        let testSuite = builder.processFile(file);
+
+        expect(testSuite).to.not.be.null;
+        expect(testSuite.isValid).to.be.true;
+        expect(testSuite.name).to.equal('MainTestSuite');
+        expect(testSuite.setupFunctionName).to.equal('MainTestSuite__SetUp');
+        expect(testSuite.tearDownFunctionName).to.equal('MainTestSuite__TearDown');
+        expect(testSuite.itGroups[0].testCases.length).to.equal(7);
+      });
+
     });
 
   });

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests.brs
@@ -1,0 +1,148 @@
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests_ignoredTests.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests_ignoredTests.brs
@@ -1,0 +1,172 @@
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    this.SetUp = MainTestSuite__SetUp
+    this.TearDown = MainTestSuite__TearDown
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' This function called immediately before running tests of current suite.
+' This function called to prepare all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__SetUp()
+    ' Target testing object. To avoid the object creation in each test
+    ' we create instance of target object here and use it in tests as m.targetTestObject.
+    m.mainData  = GetApiArray()
+End Sub
+
+'----------------------------------------------------------------
+' This function called immediately after running tests of current suite.
+' This function called to clean or remove all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__TearDown()
+    ' Remove all the test data
+    m.Delete("mainData")
+End Sub
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+'@Ignore
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'@Ignore
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests_isIgnored.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests_isIgnored.brs
@@ -1,0 +1,149 @@
+'@Ignore test to ignore this
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests_isSolo.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests_isSolo.brs
@@ -1,0 +1,149 @@
+'@Only
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests_setupAndTearDown.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests_setupAndTearDown.brs
@@ -1,0 +1,170 @@
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    this.SetUp = MainTestSuite__SetUp
+    this.TearDown = MainTestSuite__TearDown
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' This function called immediately before running tests of current suite.
+' This function called to prepare all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__SetUp()
+    ' Target testing object. To avoid the object creation in each test
+    ' we create instance of target object here and use it in tests as m.targetTestObject.
+    m.mainData  = GetApiArray()
+End Sub
+
+'----------------------------------------------------------------
+' This function called immediately after running tests of current suite.
+' This function called to clean or remove all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__TearDown()
+    ' Remove all the test data
+    m.Delete("mainData")
+End Sub
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function

--- a/src/test/stubProject/source/tests/specs/legacyFrameworkTests_solos.brs
+++ b/src/test/stubProject/source/tests/specs/legacyFrameworkTests_solos.brs
@@ -1,0 +1,172 @@
+'*****************************************************************
+'* Copyright Roku 2011-2017
+'* All Rights Reserved
+'*****************************************************************
+
+' Functions in this file:
+'
+'     TestSuite__Main
+'     MainTestSuite__SetUp
+'     MainTestSuite__TearDown
+'     TestCase__Main_CheckDataCount
+'     TestCase__Main_CheckItemAttributes
+'     TestCase__Main_CheckStreamFormatType
+'     TestCase__Main_TestAddPrefixFunction__Failed
+'     TestCase__Main_TestAddPrefixFunction__Passed
+
+'----------------------------------------------------------------
+' Main setup function.
+'
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+Function TestSuite__Main() as Object
+
+    ' Inherite your test suite from BaseTestSuite
+    this = BaseTestSuite()
+
+    ' Test suite name for log statistics
+    this.Name = "MainTestSuite"
+
+    this.SetUp = MainTestSuite__SetUp
+    this.TearDown = MainTestSuite__TearDown
+
+    ' Add tests to suite's tests collection
+    this.addTest("CheckDataCount", TestCase__Main_CheckDataCount)
+    this.addTest("CheckItemAttributes", TestCase__Main_CheckItemAttributes, TestCase__Main_CheckItemAttributes_Setup, TestCase__Main_CheckItemAttributes_TearDown)
+    this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
+    this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
+    this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
+
+    return this
+End Function
+
+'----------------------------------------------------------------
+' This function called immediately before running tests of current suite.
+' This function called to prepare all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__SetUp()
+    ' Target testing object. To avoid the object creation in each test
+    ' we create instance of target object here and use it in tests as m.targetTestObject.
+    m.mainData  = GetApiArray()
+End Sub
+
+'----------------------------------------------------------------
+' This function called immediately after running tests of current suite.
+' This function called to clean or remove all data for testing.
+'----------------------------------------------------------------
+Sub MainTestSuite__TearDown()
+    ' Remove all the test data
+    m.Delete("mainData")
+End Sub
+
+'----------------------------------------------------------------
+' Check if data has an expected amount of items
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+'@Only
+Function TestCase__Main_CheckDataCount() as String
+    return m.assertArrayCount(m.mainData, 15)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_Setup()
+    ? "--- CheckItemAttributes Test Setup function"
+    m.someVariable = "test"
+end sub
+
+'----------------------------------------------------------------
+' Check if first item has mandatory attributes
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckItemAttributes() as String
+    firstItem = m.mainData[0]
+    ? "Access some variable: " m.testinstance.someVariable
+
+    mandatoryAttributes = ["url", "title", "hdposterurl"]
+
+    return m.AssertAAHasKeys(firstItem, mandatoryAttributes)
+End Function
+
+sub TestCase__Main_CheckItemAttributes_TearDown()
+    ? "--- CheckItemAttributes Test TearDown function"
+end sub
+
+'@Only
+'----------------------------------------------------------------
+' Check if stream format of the item is expected
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_CheckStreamFormatType() as String
+    firstItem = m.mainData[0]
+    result = m.assertEqual(firstItem.streamFormat1, "mp4")
+    result += m.assertEqual(firstItem.streamFormat2, "mp4")
+    return result + m.assertEqual(firstItem.streamFormat, "mp4")
+End Function
+
+'----------------------------------------------------------------
+' Generates invalid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Failed() as String
+    'Create scheme for item generator
+    scheme = {
+        key1  : "integer"
+        key2  : "string"
+        key3  : "boolean"
+        key4  : {subKey1: "string"}
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Generates valid input object and pass it to function.
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestAddPrefixFunction__Passed() as string
+    'Create scheme for item generator
+    scheme = {
+        key1  : "string"
+        key2  : "string"
+        key3  : "string"
+        key4  : "string"
+    }
+    inputObject = ItemGenerator(scheme)
+
+    'Pass generated item to your function
+    result = AddPrefixToAAItems(inputObject)
+
+    return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
+End Function


### PR DESCRIPTION
## 3.0.9 - reintroduces legacy support

### Added

  - legacy unit testing support is reintroduced. Any projects that adhere to the roku unit testing library pre-annotation syntax, will automatically run.
    @only and @ignore is supported for test suites, and test cases.

### Changed

### Deprecated

### Removed

### Fixed

  - adds ignored test info, so that we can get that back in the log report
